### PR TITLE
chore(tests): remove redundant mineBlock() calls in integration tests

### DIFF
--- a/tests/antSourceCodeTxs.test.ts
+++ b/tests/antSourceCodeTxs.test.ts
@@ -1,7 +1,7 @@
 import { Contract, JWKInterface, PstState } from 'warp-contracts';
 
 import { IOState } from '../src/types';
-import { arweave, warp } from './setup.jest';
+import { warp } from './setup.jest';
 import {
   DEFAULT_ANT_CONTRACT_ID,
   DEFAULT_EXISTING_ANT_SOURCE_CODE_TX_MESSAGE,
@@ -10,7 +10,6 @@ import {
 import {
   getLocalArNSContractId,
   getLocalWallet,
-  mineBlock,
 } from './utils/helper';
 
 describe('ANT Source Code Transactions Ids', () => {
@@ -36,8 +35,6 @@ describe('ANT Source Code Transactions Ids', () => {
         contractTxId: RANDOM_ANT_CONTRACT_ID,
       });
 
-      await mineBlock(arweave);
-
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
       const state = cachedValue.state as IOState;
@@ -53,8 +50,6 @@ describe('ANT Source Code Transactions Ids', () => {
         function: 'addANTSourceCodeTx',
         contractTxId: RANDOM_ANT_CONTRACT_ID,
       });
-
-      await mineBlock(arweave);
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
@@ -72,8 +67,6 @@ describe('ANT Source Code Transactions Ids', () => {
         function: 'removeANTSourceCodeTx',
         contractTxId: RANDOM_ANT_CONTRACT_ID,
       });
-
-      await mineBlock(arweave);
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
@@ -101,8 +94,6 @@ describe('ANT Source Code Transactions Ids', () => {
         contractTxId: DEFAULT_ANT_CONTRACT_ID,
       });
 
-      await mineBlock(arweave);
-
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
       expect(Object.keys(cachedValue.errorMessages)).toContain(
@@ -118,8 +109,6 @@ describe('ANT Source Code Transactions Ids', () => {
         function: 'removeANTSourceCodeTx',
         contractTxId: DEFAULT_ANT_CONTRACT_ID,
       });
-
-      await mineBlock(arweave);
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();

--- a/tests/antSourceCodeTxs.test.ts
+++ b/tests/antSourceCodeTxs.test.ts
@@ -7,10 +7,7 @@ import {
   DEFAULT_EXISTING_ANT_SOURCE_CODE_TX_MESSAGE,
   DEFAULT_NON_CONTRACT_OWNER_MESSAGE,
 } from './utils/constants';
-import {
-  getLocalArNSContractId,
-  getLocalWallet,
-} from './utils/helper';
+import { getLocalArNSContractId, getLocalWallet } from './utils/helper';
 
 describe('ANT Source Code Transactions Ids', () => {
   let contract: Contract<PstState>;

--- a/tests/evolve.test.ts
+++ b/tests/evolve.test.ts
@@ -5,10 +5,7 @@ import { Contract, JWKInterface, PstState } from 'warp-contracts';
 import { IOState } from '../src/types';
 import { warp } from './setup.jest';
 import { DEFAULT_NON_CONTRACT_OWNER_MESSAGE } from './utils/constants';
-import {
-  getLocalArNSContractId,
-  getLocalWallet,
- } from './utils/helper';
+import { getLocalArNSContractId, getLocalWallet } from './utils/helper';
 
 describe('Evolve', () => {
   let contract: Contract<PstState>;

--- a/tests/evolve.test.ts
+++ b/tests/evolve.test.ts
@@ -3,13 +3,12 @@ import path from 'path';
 import { Contract, JWKInterface, PstState } from 'warp-contracts';
 
 import { IOState } from '../src/types';
-import { arweave, warp } from './setup.jest';
+import { warp } from './setup.jest';
 import { DEFAULT_NON_CONTRACT_OWNER_MESSAGE } from './utils/constants';
 import {
   getLocalArNSContractId,
   getLocalWallet,
-  mineBlock,
-} from './utils/helper';
+ } from './utils/helper';
 
 describe('Evolve', () => {
   let contract: Contract<PstState>;
@@ -38,9 +37,6 @@ describe('Evolve', () => {
         owner,
       );
       const evolveSrcTxId = await warp.saveSource(evolveSrcTx);
-
-      await mineBlock(arweave);
-
       const evolveInteraction = await contract.evolve(evolveSrcTxId, {
         disableBundling: true,
       });
@@ -71,8 +67,6 @@ describe('Evolve', () => {
       const evolveSrcTxId = await warp.saveSource(evolveSrcTx);
       const { cachedValue: prevCachedValue } = await contract.readState();
       const prevState = prevCachedValue.state as IOState;
-
-      await mineBlock(arweave);
 
       const evolveInteraction = await contract.evolve(evolveSrcTxId, {
         disableBundling: true,

--- a/tests/extend.test.ts
+++ b/tests/extend.test.ts
@@ -3,15 +3,13 @@ import { Contract, JWKInterface, PstState } from 'warp-contracts';
 import {
   DEFAULT_ARNS_NAME_DOES_NOT_EXIST_MESSAGE,
   DEFAULT_INVALID_YEARS_MESSAGE,
-  SECONDS_IN_A_YEAR,
 } from '../src/constants';
 import { IOState } from '../src/types';
-import { arweave, warp } from './setup.jest';
+import { warp } from './setup.jest';
 import { MAX_YEARS } from './utils/constants';
 import {
   getLocalArNSContractId,
   getLocalWallet,
-  mineBlock,
 } from './utils/helper';
 
 describe('Extend', () => {
@@ -43,8 +41,6 @@ describe('Extend', () => {
         years: extendYears,
       });
 
-      await mineBlock(arweave);
-
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
       const state = cachedValue.state as IOState;
@@ -70,8 +66,6 @@ describe('Extend', () => {
         years: extendYears,
       });
 
-      await mineBlock(arweave);
-
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
       const state = cachedValue.state as IOState;
@@ -94,8 +88,6 @@ describe('Extend', () => {
         name: name,
         years: extendYears,
       });
-
-      await mineBlock(arweave);
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();

--- a/tests/extend.test.ts
+++ b/tests/extend.test.ts
@@ -7,10 +7,7 @@ import {
 import { IOState } from '../src/types';
 import { warp } from './setup.jest';
 import { MAX_YEARS } from './utils/constants';
-import {
-  getLocalArNSContractId,
-  getLocalWallet,
-} from './utils/helper';
+import { getLocalArNSContractId, getLocalWallet } from './utils/helper';
 
 describe('Extend', () => {
   let contract: Contract<PstState>;

--- a/tests/fees.test.ts
+++ b/tests/fees.test.ts
@@ -1,7 +1,7 @@
 import { Contract, JWKInterface, PstState } from 'warp-contracts';
 
 import { IOState } from '../src/types';
-import { arweave, warp } from './setup.jest';
+import { warp } from './setup.jest';
 import {
   DEFAULT_INITIAL_STATE,
   DEFAULT_NON_CONTRACT_OWNER_MESSAGE,
@@ -9,7 +9,6 @@ import {
 import {
   getLocalArNSContractId,
   getLocalWallet,
-  mineBlock,
 } from './utils/helper';
 
 describe('Fees', () => {
@@ -39,8 +38,6 @@ describe('Fees', () => {
         },
       });
 
-      await mineBlock(arweave);
-
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
       const state = cachedValue.state as IOState;
@@ -67,8 +64,6 @@ describe('Fees', () => {
         },
       });
 
-      await mineBlock(arweave);
-
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
       expect(Object.keys(cachedValue.errorMessages)).toContain(
@@ -87,8 +82,6 @@ describe('Fees', () => {
           '33': 5,
         },
       });
-
-      await mineBlock(arweave);
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
@@ -118,8 +111,6 @@ describe('Fees', () => {
           '32': 5,
         },
       });
-
-      await mineBlock(arweave);
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();

--- a/tests/fees.test.ts
+++ b/tests/fees.test.ts
@@ -6,10 +6,7 @@ import {
   DEFAULT_INITIAL_STATE,
   DEFAULT_NON_CONTRACT_OWNER_MESSAGE,
 } from './utils/constants';
-import {
-  getLocalArNSContractId,
-  getLocalWallet,
-} from './utils/helper';
+import { getLocalArNSContractId, getLocalWallet } from './utils/helper';
 
 describe('Fees', () => {
   let contract: Contract<PstState>;

--- a/tests/mint.test.ts
+++ b/tests/mint.test.ts
@@ -7,10 +7,7 @@ import {
   DEFAULT_NON_CONTRACT_OWNER_MESSAGE,
   DEFAULT_TRANSFER_QTY,
 } from './utils/constants';
-import {
-  getLocalArNSContractId,
-  getLocalWallet,
-} from './utils/helper';
+import { getLocalArNSContractId, getLocalWallet } from './utils/helper';
 
 describe('Mint', () => {
   let contract: Contract<PstState>;

--- a/tests/mint.test.ts
+++ b/tests/mint.test.ts
@@ -1,11 +1,8 @@
-import * as fs from 'fs';
-import path from 'path';
 import { Contract, JWKInterface, PstState } from 'warp-contracts';
 
 import { IOState } from '../src/types';
 import { arweave, warp } from './setup.jest';
 import {
-  DEFAULT_INITIAL_STATE,
   DEFAULT_INVALID_QTY_MESSAGE,
   DEFAULT_NON_CONTRACT_OWNER_MESSAGE,
   DEFAULT_TRANSFER_QTY,
@@ -13,7 +10,6 @@ import {
 import {
   getLocalArNSContractId,
   getLocalWallet,
-  mineBlock,
 } from './utils/helper';
 
 describe('Mint', () => {
@@ -41,8 +37,6 @@ describe('Mint', () => {
         function: 'mint',
         qty: DEFAULT_TRANSFER_QTY,
       });
-      await mineBlock(arweave);
-
       expect(mintInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
       const state = cachedValue.state as IOState;
@@ -63,8 +57,6 @@ describe('Mint', () => {
         function: 'mint',
         qty: 0,
       });
-      await mineBlock(arweave);
-
       expect(mintInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
       const state = cachedValue.state as IOState;
@@ -97,8 +89,6 @@ describe('Mint', () => {
         function: 'mint',
         qty: DEFAULT_TRANSFER_QTY,
       });
-      await mineBlock(arweave);
-
       expect(mintInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue } = await contract.readState();
       const state = cachedValue.state as IOState;

--- a/tests/records.test.ts
+++ b/tests/records.test.ts
@@ -55,7 +55,6 @@ describe('Records', () => {
           },
         );
 
-  
         const purchasedTierId =
           prevState.tiers.current[namePurchase.tierNumber!];
         const purchasedTier = prevState.tiers.history.find(
@@ -105,7 +104,6 @@ describe('Records', () => {
           },
         );
 
-  
         const purchasedTierId =
           prevState.tiers.current[ALLOWED_ACTIVE_TIERS[0]];
         const purchasedTier = prevState.tiers.history.find(
@@ -244,7 +242,6 @@ describe('Records', () => {
           },
         );
 
-  
         const purchasedTierId =
           prevState.tiers.current[namePurchase.tierNumber!];
         const purchasedTier = prevState.tiers.history.find(
@@ -374,7 +371,6 @@ describe('Records', () => {
               disableBundling: true,
             },
           );
-
 
           expect(writeInteraction?.originalTxId).not.toBe(undefined);
           const { cachedValue } = await contract.readState();

--- a/tests/records.test.ts
+++ b/tests/records.test.ts
@@ -14,7 +14,6 @@ import {
   calculateTotalRegistrationFee,
   getLocalArNSContractId,
   getLocalWallet,
-  mineBlock,
 } from './utils/helper';
 
 describe('Records', () => {
@@ -56,8 +55,7 @@ describe('Records', () => {
           },
         );
 
-        await mineBlock(arweave);
-
+  
         const purchasedTierId =
           prevState.tiers.current[namePurchase.tierNumber!];
         const purchasedTier = prevState.tiers.history.find(
@@ -107,8 +105,7 @@ describe('Records', () => {
           },
         );
 
-        await mineBlock(arweave);
-
+  
         const purchasedTierId =
           prevState.tiers.current[ALLOWED_ACTIVE_TIERS[0]];
         const purchasedTier = prevState.tiers.history.find(
@@ -247,8 +244,7 @@ describe('Records', () => {
           },
         );
 
-        await mineBlock(arweave);
-
+  
         const purchasedTierId =
           prevState.tiers.current[namePurchase.tierNumber!];
         const purchasedTier = prevState.tiers.history.find(
@@ -297,8 +293,6 @@ describe('Records', () => {
           },
         );
 
-        await mineBlock(arweave);
-
         const purchasedTierId = prevState.tiers.current[1];
         const purchasedTier = prevState.tiers.history.find(
           (t) => t.id === purchasedTierId,
@@ -345,8 +339,6 @@ describe('Records', () => {
           },
         );
 
-        await mineBlock(arweave);
-
         expect(writeInteraction?.originalTxId).not.toBe(undefined);
         const { cachedValue } = await contract.readState();
         expect(Object.keys(cachedValue.errorMessages)).toContain(
@@ -383,7 +375,6 @@ describe('Records', () => {
             },
           );
 
-          await mineBlock(arweave);
 
           expect(writeInteraction?.originalTxId).not.toBe(undefined);
           const { cachedValue } = await contract.readState();

--- a/tests/tiers.test.ts
+++ b/tests/tiers.test.ts
@@ -7,10 +7,7 @@ import {
 } from '../src/constants';
 import { IOState, ServiceTier } from '../src/types';
 import { warp } from './setup.jest';
-import {
-  getLocalArNSContractId,
-  getLocalWallet,
-} from './utils/helper';
+import { getLocalArNSContractId, getLocalWallet } from './utils/helper';
 
 describe('Tiers', () => {
   let contract: Contract<PstState>;

--- a/tests/tiers.test.ts
+++ b/tests/tiers.test.ts
@@ -1,4 +1,4 @@
-import { Contract, JWKInterface, PstContract, PstState } from 'warp-contracts';
+import { Contract, JWKInterface, PstState } from 'warp-contracts';
 
 import {
   ALLOWED_ACTIVE_TIERS,
@@ -6,11 +6,10 @@ import {
   DEFAULT_NON_CONTRACT_OWNER_MESSAGE,
 } from '../src/constants';
 import { IOState, ServiceTier } from '../src/types';
-import { arweave, warp } from './setup.jest';
+import { warp } from './setup.jest';
 import {
   getLocalArNSContractId,
   getLocalWallet,
-  mineBlock,
 } from './utils/helper';
 
 describe('Tiers', () => {
@@ -46,7 +45,6 @@ describe('Tiers', () => {
           disableBundling: true,
         },
       );
-      await mineBlock(arweave);
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue: newCachedValue } = await contract.readState();
@@ -69,7 +67,6 @@ describe('Tiers', () => {
           disableBundling: true,
         },
       );
-      await mineBlock(arweave);
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue: newCachedValue } = await contract.readState();
       const newState = newCachedValue.state as IOState;
@@ -91,7 +88,6 @@ describe('Tiers', () => {
           disableBundling: true,
         },
       );
-      await mineBlock(arweave);
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue: newCachedValue } = await contract.readState();
@@ -115,7 +111,6 @@ describe('Tiers', () => {
           disableBundling: true,
         },
       );
-      await mineBlock(arweave);
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue: newCachedValue } = await contract.readState();
@@ -152,7 +147,6 @@ describe('Tiers', () => {
           disableBundling: true,
         },
       );
-      await mineBlock(arweave);
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue: newCachedValue } = await contract.readState();
@@ -182,7 +176,6 @@ describe('Tiers', () => {
           disableBundling: true,
         },
       );
-      await mineBlock(arweave);
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue: newCachedValue } = await contract.readState();

--- a/tests/transfer.test.ts
+++ b/tests/transfer.test.ts
@@ -7,10 +7,7 @@ import {
   DEFAULT_INVALID_TARGET_MESSAGE,
   DEFAULT_TRANSFER_QTY,
 } from './utils/constants';
-import {
-  getLocalArNSContractId,
-  getLocalWallet,
-} from './utils/helper';
+import { getLocalArNSContractId, getLocalWallet } from './utils/helper';
 
 describe('Transfers', () => {
   let contract: Contract<PstState>;

--- a/tests/transfer.test.ts
+++ b/tests/transfer.test.ts
@@ -10,7 +10,6 @@ import {
 import {
   getLocalArNSContractId,
   getLocalWallet,
-  mineBlock,
 } from './utils/helper';
 
 describe('Transfers', () => {
@@ -43,8 +42,6 @@ describe('Transfers', () => {
         qty: DEFAULT_TRANSFER_QTY,
       });
 
-      await mineBlock(arweave);
-
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue: newCachedValue } = await contract.readState();
       const newState = newCachedValue.state as IOState;
@@ -73,8 +70,6 @@ describe('Transfers', () => {
         qty: Math.pow(DEFAULT_TRANSFER_QTY, 10),
       });
 
-      await mineBlock(arweave);
-
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue: newCachedValue } = await contract.readState();
       const newState = newCachedValue.state as IOState;
@@ -98,8 +93,6 @@ describe('Transfers', () => {
         target: ownerAddress,
         qty: DEFAULT_TRANSFER_QTY,
       });
-
-      await mineBlock(arweave);
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue: newCachedValue } = await contract.readState();
@@ -136,8 +129,6 @@ describe('Transfers', () => {
         qty: DEFAULT_TRANSFER_QTY,
       });
 
-      await mineBlock(arweave);
-
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue: newCachedValue } = await contract.readState();
       const newState = newCachedValue.state as IOState;
@@ -162,8 +153,6 @@ describe('Transfers', () => {
         target: callerAddress,
         qty: DEFAULT_TRANSFER_QTY,
       });
-
-      await mineBlock(arweave);
 
       expect(writeInteraction?.originalTxId).not.toBe(undefined);
       const { cachedValue: newCachedValue } = await contract.readState();


### PR DESCRIPTION
## Details
- when using `arlocal` with `warp`, `writeInteractions` by default `mineBlocks` after they post. no need to call it explicitly in these tests