### PR TITLE
fix(pst): update balance function to be PST compliant, and modify typ…

### DIFF
--- a/src/contract.ts
+++ b/src/contract.ts
@@ -30,7 +30,12 @@ import { transferTokens } from './actions/write/transferTokens';
 import { updateGatewaySettings } from './actions/write/updateGatewaySettings';
 import { updateState } from './actions/write/updateState';
 import { upgradeTier } from './actions/write/upgradeTier';
-import { ContractResult, IOState, PstAction, PstFunction } from './types';
+import {
+  ContractResult,
+  IOContractFunctions,
+  IOState,
+  PstAction,
+} from './types';
 
 declare const ContractError;
 
@@ -40,7 +45,7 @@ export async function handle(
 ): Promise<ContractResult> {
   const input = action.input;
 
-  switch (input.function as PstFunction) {
+  switch (input.function as IOContractFunctions) {
     case 'transfer':
       return await transferTokens(state, action);
     case 'mint':
@@ -65,21 +70,21 @@ export async function handle(
       return await addANTSourceCodeTx(state, action);
     case 'removeANTSourceCodeTx':
       return await removeANTSourceCodeTx(state, action);
-    case 'getBalance':
+    case 'balance':
       return await getBalance(state, action);
-    case 'getRecord':
+    case 'record':
       return await getRecord(state, action);
-    case 'getTier':
+    case 'tier':
       return await getTier(state, action);
-    case 'getActiveTiers':
+    case 'activeTiers':
       return await getActiveTiers(state);
-    case 'getGateway':
+    case 'gateway':
       return await getGateway(state, action);
-    case 'getGatewayTotalStake':
+    case 'gatewayTotalStake':
       return await getGatewayTotalStake(state, action);
-    case 'getGatewayRegistry':
+    case 'gatewayRegistry':
       return await getGatewayRegistry(state);
-    case 'getRankedGatewayRegistry':
+    case 'rankedGatewayRegistry':
       return await getRankedGatewayRegistry(state);
     case 'upgradeTier':
       return await upgradeTier(state, action);

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,9 +174,10 @@ export type ArNSNamePurchase = {
   contractTxId: string;
 };
 
+// TODO: break this up
 export type PstInput = {
   type: FoundationActionType;
-  function: PstFunction;
+  function: IOContractFunctions;
   target: string;
   value: string | number;
   name: string;
@@ -232,38 +233,41 @@ export type ServiceTierSettings = {
   maxUndernames: number;
 };
 
-// TODO: handle purchasing additional undernames
-export type PstFunction =
-  | 'transfer'
-  | 'transferLocked'
-  | 'mint'
+export type PstFunctions = 'balance' | 'transfer' | 'evolve';
+
+export type PDNSFunctions =
   | 'setFees'
-  | 'evolve'
   | 'buyRecord'
   | 'removeRecord'
   | 'extendRecord'
   | 'addANTSourceCodeTx'
   | 'removeANTSourceCodeTx'
-  | 'getBalance'
-  | 'getRecord'
-  | 'getGateway'
-  | 'getGatewayTotalStake'
-  | 'getGatewayRegistry'
-  | 'getRankedGatewayRegistry'
-  | 'updateState'
   | 'setName'
   | 'setActiveTier'
   | 'createNewTier'
-  | 'getTier'
-  | 'getActiveTiers'
+  | 'tier'
+  | 'activeTiers'
   | 'upgradeTier'
+  | 'record';
+
+export type GARFunctions =
   | 'joinNetwork'
+  | 'gatewayRegistry'
+  | 'gatewayTotalStake'
   | 'initiateLeave'
   | 'finalizeLeave'
   | 'increaseOperatorStake'
+  | 'rankedGatewayRegistry'
   | 'initiateOperatorStakeDecrease'
   | 'finalizeOperatorStakeDecrease'
   | 'updateGatewaySettings';
+
+export type FoundationFunctions = 'gateway' | 'updateState' | 'mint';
+
+export type IOContractFunctions = FoundationFunctions &
+  GARFunctions &
+  PDNSFunctions &
+  PstFunctions;
 
 export type ContractResult =
   | { state: IOState }

--- a/tests/balance.test.ts
+++ b/tests/balance.test.ts
@@ -1,0 +1,54 @@
+import { Contract, JWKInterface, PstState } from 'warp-contracts';
+
+import { IOState } from '../src/types.js';
+import { arweave, warp } from './setup.jest';
+import { getLocalArNSContractId, getLocalWallet } from './utils/helper';
+
+describe('Balance', () => {
+  let contract: Contract<PstState>;
+  let srcContractId: string;
+
+  beforeAll(async () => {
+    srcContractId = getLocalArNSContractId();
+  });
+
+  describe('non-contract owner', () => {
+    let nonContractOwner: JWKInterface;
+
+    beforeAll(async () => {
+      nonContractOwner = getLocalWallet(1);
+      contract = warp.pst(srcContractId).connect(nonContractOwner);
+    });
+
+    it('should able to retrieve its own balance', async () => {
+      const nonContractOwnerAddress = await arweave.wallets.getAddress(
+        nonContractOwner,
+      );
+      const { cachedValue: prevCachedValue } = await contract.readState();
+      const prevState = prevCachedValue.state as IOState;
+      const prevNonOwnerBalance = prevState.balances[nonContractOwnerAddress];
+      const { result } = (await contract.viewState({
+        function: 'balance',
+        target: nonContractOwnerAddress,
+      })) as any;
+      expect(result).not.toBe(undefined);
+      expect(result.target).toEqual(nonContractOwnerAddress);
+      expect(result.balance).toEqual(prevNonOwnerBalance);
+    });
+
+    it('should able to retrieve another wallets balance', async () => {
+      const otherWallet = getLocalWallet(2);
+      const otherWalletAddress = await arweave.wallets.getAddress(otherWallet);
+      const { cachedValue: prevCachedValue } = await contract.readState();
+      const prevState = prevCachedValue.state as IOState;
+      const prevNonOwnerBalance = prevState.balances[otherWalletAddress];
+      const { result } = (await contract.viewState({
+        function: 'balance',
+        target: otherWalletAddress,
+      })) as any;
+      expect(result).not.toBe(undefined);
+      expect(result.target).toEqual(otherWalletAddress);
+      expect(result.balance).toEqual(prevNonOwnerBalance);
+    });
+  });
+});

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -421,7 +421,7 @@ describe('Network', () => {
     describe('read interactions', () => {
       it('should be able to fetch gateway details via view state', async () => {
         const { result: gateway } = await contract.viewState({
-          function: 'getGateway',
+          function: 'gateway',
           target: ownerAddress,
         });
         const expectedGatewayObj = expect.objectContaining({
@@ -438,7 +438,7 @@ describe('Network', () => {
 
       it('should be return an error when fetching a non-existent gateway via viewState', async () => {
         const response = await contract.viewState({
-          function: 'getGateway',
+          function: 'gateway',
           target: 'non-existent-gateway',
         });
         expect(response).not.toBe(undefined);
@@ -451,7 +451,7 @@ describe('Network', () => {
         const { cachedValue } = await contract.readState();
         const fullState = cachedValue.state as IOState;
         const { result: gatewayTotalStake } = await contract.viewState({
-          function: 'getGatewayTotalStake',
+          function: 'gatewayTotalStake',
           target: ownerAddress,
         });
         expect(gatewayTotalStake).toEqual(
@@ -464,7 +464,7 @@ describe('Network', () => {
         const { cachedValue } = await contract.readState();
         const fullState = cachedValue.state as IOState;
         const { result: gateways } = await contract.viewState({
-          function: 'getGatewayRegistry',
+          function: 'gatewayRegistry',
         });
         expect(gateways).not.toBe(undefined);
         expect(gateways).toEqual(fullState.gateways);
@@ -472,7 +472,7 @@ describe('Network', () => {
 
       it('should be able to fetch stake ranked, active gateway address registry via view state', async () => {
         const { result: rankedGateways } = await contract.viewState({
-          function: 'getRankedGatewayRegistry',
+          function: 'rankedGatewayRegistry',
         });
         expect(rankedGateways).not.toBe(undefined); // TODO, make this more specific
       });

--- a/tests/records.test.ts
+++ b/tests/records.test.ts
@@ -195,7 +195,7 @@ describe('Records', () => {
     describe('read interactions', () => {
       it('should be able to fetch record details via view state', async () => {
         const { result: record } = await contract.viewState({
-          function: 'getRecord',
+          function: 'record',
           name: 'name1',
         });
         const expectedTierObj = expect.objectContaining({
@@ -215,7 +215,7 @@ describe('Records', () => {
 
       it('should be return an error when fetching a non-existent record via viewState', async () => {
         const response = await contract.viewState({
-          function: 'getRecord',
+          function: 'record',
           name: 'non-existent-name',
         });
         expect(response).not.toBe(undefined);

--- a/tests/tiers.test.ts
+++ b/tests/tiers.test.ts
@@ -223,7 +223,7 @@ describe('Tiers', () => {
   describe('no wallet', () => {
     it('should be able to get a tier via viewState', async () => {
       const { result: tier } = await contract.viewState({
-        function: 'getTier',
+        function: 'tier',
         tierNumber: 1,
       });
       expect(tier).not.toBe(undefined);
@@ -238,7 +238,7 @@ describe('Tiers', () => {
 
     it('should be able to get active tiers via viewState', async () => {
       const { result: activeTiers } = await contract.viewState({
-        function: 'getActiveTiers',
+        function: 'activeTiers',
       });
       const expectedTierObj = expect.objectContaining({
         tier: expect.any(String),

--- a/tools/evolve-contract.ts
+++ b/tools/evolve-contract.ts
@@ -13,7 +13,7 @@ import { keyfile } from './constants';
 (async () => {
   // This is the mainnet ArNS Registry Smartweave Contract TX ID version 1.7
   const arnsRegistryContractTxId =
-    'k0yfvCpbusgE7a6JrqFVmoTWWJSQV4Zte3EVoLgd8dw';
+    'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
 
   // ~~ Initialize `LoggerFactory` ~~
   LoggerFactory.INST.logLevel('error');


### PR DESCRIPTION
…es to be more explicit' (#22)

* fix(pst): update functions to be pst compliant

Moving 'balance' to 'getBalance' no longer adheres to PST requirements. Updating functions and breaking apart types, so these are explicit. We should continue this pattern going forward.

* chore: formatting

* chore(tests): update existing tests and add checks for balances

* chore: linting

---------