### PR TITLE
fix: move auction settings into auction obj

### DIFF
--- a/src/actions/read/auction.ts
+++ b/src/actions/read/auction.ts
@@ -14,19 +14,15 @@ export const getAuction = (
     throw new ContractError(`No live auction exists for ${auction}`);
   }
 
-  const { auctionSettingsId, startHeight, floorPrice, startPrice } = auction;
-  const auctionSettings = settings.auctions.history.find(
-    (a) => a.id === auctionSettingsId,
-  );
-
-  if (!auctionSettings) {
-    throw new ContractError(
-      `Auction settings with id ${auctionSettingsId} does not exist.`,
-    );
-  }
-
-  const { auctionDuration, decayRate, decayInterval } = auctionSettings;
-  const intervalCount = auctionDuration / decayInterval;
+  const {
+    startHeight,
+    endHeight,
+    decayInterval,
+    decayRate,
+    floorPrice,
+    startPrice,
+  } = auction;
+  const intervalCount = (startHeight - endHeight) / decayInterval;
   const prices = {};
   for (let i = 0; i <= intervalCount; i++) {
     const intervalHeight = startHeight + i * decayInterval;

--- a/src/actions/write/submitAuctionBid.ts
+++ b/src/actions/write/submitAuctionBid.ts
@@ -224,7 +224,7 @@ export const submitAuctionBid = (
   // current auction in the state, validate the bid and update state
   if (auctions[name]) {
     const existingAuction = auctions[name];
-    const auctionEndHeight = existingAuction.startHeight + auctionDuration;
+    const auctionEndHeight = existingAuction.startHeight + duration;
     const endTimestamp =
       existingAuction.type === 'lease'
         ? +SmartWeave.block.timestamp +

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { AuctionSettings } from './types';
+import { Auction, AuctionSettings } from './types';
 
 export const MAX_YEARS = 5; // the maximum amount of years an arns name could be leased for
 export const NAMESPACE_LENGTH = 62; // browser domains are max 63 characters between periods, but we need to leave 1 character for the underscore seperator between the undernames and arns name
@@ -100,21 +100,10 @@ export const FEE_STRUCTURE = {
   '50': 50,
   '51': 50,
 };
-export const AUCTION_SETTINGS_ID =
-  '3IkWJ-0HdwuATDhBXuJRm0bWspXOOkRjxTm-5R2xRbw';
-export const AUCTION_SETTINGS: {
-  current: string;
-  history: AuctionSettings[];
-} = {
-  current: AUCTION_SETTINGS_ID,
-  history: [
-    {
-      id: AUCTION_SETTINGS_ID,
-      floorPriceMultiplier: 2,
-      startPriceMultiplier: 200,
-      decayInterval: 60, // decrement every 60 blocks - approx every 2 hours
-      decayRate: 0.05, // 5% decay
-      auctionDuration: 5040, // approx 7 days long
-    },
-  ],
+export const AUCTION_SETTINGS: AuctionSettings = {
+  floorPriceMultiplier: 2,
+  startPriceMultiplier: 200,
+  decayInterval: 60, // decrement every 60 blocks - approx every 2 hours
+  decayRate: 0.05, // 5% decay
+  duration: 5040, // approx 7 days long
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,9 @@ export type Auction = {
   startPrice: number;
   floorPrice: number;
   startHeight: number;
-  auctionSettingsId: string;
+  endHeight: number;
+  decayRate: number;
+  decayInterval: number;
   type: 'lease' | 'permabuy';
   initiator: string;
   contractTxId: string;
@@ -56,11 +58,10 @@ export type Auction = {
 };
 
 export type AuctionSettings = {
-  id: string;
   floorPriceMultiplier: number; // if we ever want to drop prices
   // premiumNameFloorPrice: number; // the floor price for names marked as premium
   startPriceMultiplier: number;
-  auctionDuration: number;
+  duration: number;
   decayRate: number;
   decayInterval: number;
 };
@@ -74,10 +75,6 @@ export type ContractSettings = {
     minGatewayJoinLength: number; // the minimum amount of blocks a gateway can be joined to the ar.io network
     gatewayLeaveLength: number; // the amount of blocks that have to elapse before a gateway leaves the network
     operatorStakeWithdrawLength: number; // the amount of blocks that have to elapse before a gateway operator's stake is returned
-  };
-  auctions: {
-    current: string;
-    history: AuctionSettings[];
   };
   permabuy: {
     multiplier: number;

--- a/tests/auctions.test.ts
+++ b/tests/auctions.test.ts
@@ -193,11 +193,15 @@ describe('Auctions', () => {
                   floorPrice: expect.any(Number),
                   startPrice: expect.any(Number),
                   type: 'lease',
-                  auctionSettingsId: AUCTION_SETTINGS.current,
                   startHeight: await getCurrentBlock(arweave),
                   initiator: nonContractOwnerAddress,
                   contractTxId: ANT_CONTRACT_IDS[0],
                   years: 1,
+                  endHeight:
+                    (await getCurrentBlock(arweave)) +
+                    AUCTION_SETTINGS.duration,
+                  decayRate: AUCTION_SETTINGS.decayRate,
+                  decayInterval: AUCTION_SETTINGS.decayInterval,
                 }),
               );
               expect(balances[nonContractOwnerAddress]).toEqual(
@@ -252,16 +256,14 @@ describe('Auctions', () => {
 
               it('should update the records object when a winning bid comes in', async () => {
                 // fast forward a few blocks, then construct winning bid
-                const auctionSettings: AuctionSettings =
-                  AUCTION_SETTINGS.history[0];
                 await mineBlocks(arweave, 3504);
                 const winningBidQty = calculateMinimumAuctionBid({
                   startHeight: auctionObj.startHeight,
                   startPrice: auctionObj.startPrice,
                   floorPrice: auctionObj.floorPrice,
                   currentBlockHeight: await getCurrentBlock(arweave),
-                  decayInterval: auctionSettings.decayInterval,
-                  decayRate: auctionSettings.decayRate,
+                  decayInterval: AUCTION_SETTINGS.decayInterval,
+                  decayRate: AUCTION_SETTINGS.decayRate,
                 });
                 const auctionBid = {
                   name: 'apple',
@@ -433,8 +435,11 @@ describe('Auctions', () => {
                 floorPrice: expect.any(Number),
                 startPrice: expect.any(Number),
                 type: 'lease',
-                auctionSettingsId: AUCTION_SETTINGS.current,
                 startHeight: await getCurrentBlock(arweave),
+                endHeight:
+                  (await getCurrentBlock(arweave)) + AUCTION_SETTINGS.duration,
+                decayRate: AUCTION_SETTINGS.decayRate,
+                decayInterval: AUCTION_SETTINGS.decayInterval,
                 initiator: nonContractOwnerAddress,
                 contractTxId: ANT_CONTRACT_IDS[0],
                 years: 1,
@@ -477,8 +482,11 @@ describe('Auctions', () => {
             floorPrice: expect.any(Number),
             startPrice: expect.any(Number),
             type: 'permabuy',
-            auctionSettingsId: AUCTION_SETTINGS.current,
             startHeight: await getCurrentBlock(arweave),
+            endHeight:
+              (await getCurrentBlock(arweave)) + AUCTION_SETTINGS.duration,
+            decayRate: AUCTION_SETTINGS.decayRate,
+            decayInterval: AUCTION_SETTINGS.decayInterval,
             initiator: nonContractOwnerAddress,
             contractTxId: ANT_CONTRACT_IDS[0],
           });
@@ -493,15 +501,14 @@ describe('Auctions', () => {
 
         it('should update the records object when a winning bid comes in', async () => {
           // fast forward a few blocks, then construct winning bid
-          const auctionSettings: AuctionSettings = AUCTION_SETTINGS.history[0];
           await mineBlocks(arweave, 3504);
           const winningBidQty = calculateMinimumAuctionBid({
             startHeight: auctionObj.startHeight,
             startPrice: auctionObj.startPrice,
             floorPrice: auctionObj.floorPrice,
             currentBlockHeight: await getCurrentBlock(arweave),
-            decayInterval: auctionSettings.decayInterval,
-            decayRate: auctionSettings.decayRate,
+            decayInterval: AUCTION_SETTINGS.decayInterval,
+            decayRate: AUCTION_SETTINGS.decayRate,
           });
           const auctionBid = {
             name: 'microsoft',
@@ -565,8 +572,11 @@ describe('Auctions', () => {
             floorPrice: expect.any(Number),
             startPrice: expect.any(Number),
             type: 'lease',
-            auctionSettingsId: AUCTION_SETTINGS.current,
             startHeight: await getCurrentBlock(arweave),
+            endHeight:
+              (await getCurrentBlock(arweave)) + AUCTION_SETTINGS.duration,
+            decayRate: AUCTION_SETTINGS.decayRate,
+            decayInterval: AUCTION_SETTINGS.decayInterval,
             initiator: nonContractOwnerAddress,
             contractTxId: ANT_CONTRACT_IDS[0],
             years: 1,
@@ -582,15 +592,14 @@ describe('Auctions', () => {
 
         it('should update the records when the caller is the initiator, and only withdraw the difference of the current bid to the original floor price that was already withdrawn from the initiator', async () => {
           // fast forward a few blocks, then construct winning bid
-          const auctionSettings: AuctionSettings = AUCTION_SETTINGS.history[0];
           await mineBlocks(arweave, 3504);
           const winningBidQty = calculateMinimumAuctionBid({
             startHeight: auctionObj.startHeight,
             startPrice: auctionObj.startPrice,
             floorPrice: auctionObj.floorPrice,
             currentBlockHeight: await getCurrentBlock(arweave),
-            decayInterval: auctionSettings.decayInterval,
-            decayRate: auctionSettings.decayRate,
+            decayInterval: AUCTION_SETTINGS.decayInterval,
+            decayRate: AUCTION_SETTINGS.decayRate,
           });
           const auctionBid = {
             name: 'tesla',

--- a/tests/utils/helper.ts
+++ b/tests/utils/helper.ts
@@ -261,7 +261,6 @@ export async function setupInitialContractState(
   // configure the necessary contract settings
   state.settings = {
     registry: CONTRACT_SETTINGS,
-    auctions: AUCTION_SETTINGS,
     permabuy: {
       multiplier: 100,
     },

--- a/tools/update-state.ts
+++ b/tools/update-state.ts
@@ -40,23 +40,13 @@ import { keyfile } from './constants';
     updateCacheForEachInteraction: true,
   });
   contract.connect(wallet);
-
-  const { cachedValue } = await contract.readState();
-  const { records: prevRecords } = cachedValue.state as IOState;
-  for (const name in prevRecords) {
-    // Create the evolved source code tx
-    if (!prevRecords[name].undernames) {
-      console.log('Updating record undername count for', name);
-      const writeInteraction = await contract.writeInteraction(
-        {
-          function: 'increaseUndernameCount',
-          qty: 1,
-          name,
-        },
-        {
-          disableBundling: true,
-        },
-      );
-    }
-  }
+  const writeInteraction = await contract.writeInteraction(
+    {
+      function: 'evolveState',
+    },
+    {
+      disableBundling: true,
+    },
+  );
+  console.log('Write interaction', writeInteraction);
 })();


### PR DESCRIPTION
## Details
Auction settings will require a fork instead of a foundation action. 

```
"auctions": {
    "permabuy": {
          "floorPrice": 5001000,
          "startPrice": 1000200000,
          "contractTxId": "XE3jajOxaCqeCVQswZC-OFX37zOCUHCgKLYvGHBgPQ4",
          "startHeight": 1208803,
          "endHeight": 1213843,
          "decayRate": "0.05",
          "decayInterval": 60,
          "type": "permabuy",
          "initiator": "q6zIf3KQRMCW9fytR0YlKG4oqw6Cox4r_bk7mq6JZBM"
    }
}
```